### PR TITLE
DEV: refactor BufferedProperty usage in TlpThumbnailSelector

### DIFF
--- a/javascripts/discourse/components/modal/tlp-thumbnail-selector.js
+++ b/javascripts/discourse/components/modal/tlp-thumbnail-selector.js
@@ -1,8 +1,15 @@
 import Component from "@ember/component";
-import { action } from "@ember/object";
-import { bufferedProperty } from "discourse/mixins/buffered-content";
+import { action, computed } from "@ember/object";
+import BufferedProxy from "ember-buffered-proxy/proxy";
 
-export default Component.extend(bufferedProperty("model"), {
+export default Component.extend({
+  @computed("model")
+  buffered(model) {
+    return BufferedProxy.create({
+      content: model,
+    });
+  },
+
   @action
   selectThumbnail(image_url, image_upload_id) {
     this.set("model.buffered.user_chosen_thumbnail_url", image_url);


### PR DESCRIPTION
This is for facilitating the upcoming removal of the BufferedProperty mixin, the main refactor was in https://github.com/discourse/discourse/pull/31926, and a reference PR using computed properties at https://github.com/discourse/discourse-teambuild/pull/98.