### PR TITLE
FIX: breaking line-height for .list-vote-count

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -462,7 +462,6 @@ img.thumbnail {
   display: inline-block;
   position: relative;
   top: 0;
-  line-height: 0.01em;
   vertical-align: 0.125em;
 
   .vote-count {


### PR DESCRIPTION
The `<a href>` box for vote count is too small to fit the content when line-height is .01em;
> Closed other pull request since it was the master branch